### PR TITLE
Syncfifo dRST parameter addition

### DIFF
--- a/src/Libraries/Base1/Clocks.bsv
+++ b/src/Libraries/Base1/Clocks.bsv
@@ -1299,7 +1299,7 @@ import "BVI" SyncFIFO =
 module vSyncFIFO #(Integer depthIn
                   )(
                     Clock sClkIn, Reset sRstIn,
-                    Clock dClkIn,
+                    Clock dClkIn, Reset dRstIn,
                     SyncFIFOIfc #(a) ifc)
 
    provisos (Bits#(a,sa));
@@ -1321,11 +1321,12 @@ module vSyncFIFO #(Integer depthIn
    input_clock clk_dst ( dCLK, (*unused*)dCLK_GATE ) = dClkIn;
 
    input_reset (sRST) clocked_by (clk_src) = sRstIn ;
+   input_reset (dRST) clocked_by (clk_dst) = dRstIn ;
 
    method enq ( sD_IN )  ready(sFULL_N)  enable(sENQ) clocked_by(clk_src) reset_by(sRstIn);
-   method deq ()         ready(dEMPTY_N) enable(dDEQ) clocked_by(clk_dst) reset_by(no_reset);
-   method dD_OUT first() ready(dEMPTY_N)              clocked_by(clk_dst) reset_by(no_reset);
-   method dEMPTY_N notEmpty()                         clocked_by(clk_dst) reset_by(no_reset);
+   method deq ()         ready(dEMPTY_N) enable(dDEQ) clocked_by(clk_dst) reset_by(dRstIn);
+   method dD_OUT first() ready(dEMPTY_N)              clocked_by(clk_dst) reset_by(dRstIn);
+   method dEMPTY_N notEmpty()                         clocked_by(clk_dst) reset_by(dRstIn);
    method sFULL_N notFull()                           clocked_by(clk_src) reset_by(sRstIn);
 
       schedule first SB deq;
@@ -1487,7 +1488,7 @@ module mkSyncFIFO #( Integer depthIn
      (*hide*)
       _ifc <- (depthIn == 1) ?
               vSyncFIFO1(sClkIn, sRstIn, dClkIn, dRstIn) :
-	      vSyncFIFO(depthIn, sClkIn, sRstIn, dClkIn) ;
+	      vSyncFIFO(depthIn, sClkIn, sRstIn, dClkIn, dRstIn) ;
    end
 
    return _ifc ;

--- a/src/Verilog/SyncFIFO.v
+++ b/src/Verilog/SyncFIFO.v
@@ -31,6 +31,7 @@ module SyncFIFO(
                 sCLK,
                 sRST,
                 dCLK,
+                dRST,
                 sENQ,
                 sD_IN,
                 sFULL_N,
@@ -53,6 +54,7 @@ module SyncFIFO(
 
    // destination clock domain ports
    input                     dCLK ;
+   input                     dRST;
    input                     dDEQ ;
    output                    dEMPTY_N ;
    output [dataWidth -1 : 0] dD_OUT ;
@@ -77,7 +79,7 @@ module SyncFIFO(
    wire                      dNextNotEmpty;
 
    // Reset generation
-   wire                      dRST ;
+   // wire                      dRST ;
 
    // flops to sychronize enqueue and dequeue point across domains
    reg [indxWidth : 0]       dSyncReg1, dEnqPtr ;
@@ -86,7 +88,7 @@ module SyncFIFO(
    wire [indxWidth - 1 :0]   sEnqPtrIndx, dDeqPtrIndx ;
 
    // Resets
-   assign                    dRST = sRST ;
+   // assign                    dRST = sRST ;
 
    // Outputs
    assign                    dD_OUT   = dDoutReg     ;


### PR DESCRIPTION
Added destination reset parameter to SyncFIFO.v module. It is used when mkSyncFIFO has a depth of more than 1.